### PR TITLE
Shorter tokens

### DIFF
--- a/includes/Core/JumpToCheckout.php
+++ b/includes/Core/JumpToCheckout.php
@@ -99,16 +99,10 @@ class JumpToCheckout {
 				$token .= $characters[ wp_rand( 0, strlen( $characters ) - 1 ) ];
 			}
 
-			// Check if token already exists.
-			$table_name = $wpdb->prefix . 'jptc_links';
-			$exists     = $wpdb->get_var(
-				$wpdb->prepare(
-					"SELECT COUNT(*) FROM {$table_name} WHERE token = %s",
-					$token
-				)
-			);
+			// Check if token already exists using Database class method.
+			$existing_link = $this->db->get_link_by_token( $token );
 
-			if ( ! $exists ) {
+			if ( ! $existing_link ) {
 				return $token;
 			}
 		}

--- a/jump-to-checkout.php
+++ b/jump-to-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jump to Checkout
  * Plugin URI:  https://close.technology/wordpress-plugins/jump-to-checkout-pro/
  * Description: Generate direct checkout links with pre-selected products for WooCommerce.
- * Version:     1.0.1
+ * Version:     1.0.2-beta.1
  * Author:      Close Marketing
  * Author URI:  https://close.marketing
  * Text Domain: jump-to-checkout
@@ -24,7 +24,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'JTPC_VERSION', '1.0.1' );
+define( 'JTPC_VERSION', '1.0.2-beta.1' );
 define( 'JTPC_PLUGIN', __FILE__ );
 define( 'JTPC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'JTPC_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
@@ -45,6 +45,10 @@ add_action( 'plugins_loaded', 'jptc_plugin_init' );
 function jptc_plugin_init() {
 	// Initialize plugin classes.
 	if ( class_exists( 'CLOSE\JumpToCheckout\Core\JumpToCheckout' ) ) {
+		// Check and update database if needed.
+		$db = new CLOSE\JumpToCheckout\Database\Database();
+		$db->maybe_create_table();
+
 		new CLOSE\JumpToCheckout\Core\JumpToCheckout();
 		new CLOSE\JumpToCheckout\Admin\AdminPanel();
 		new CLOSE\JumpToCheckout\Admin\LinksManager();

--- a/readme.txt
+++ b/readme.txt
@@ -189,6 +189,9 @@ Statistics export is available in the PRO version (CSV/Excel format).
 
 == Changelog ==
 
+= 1.0.2 =
+* Length of the token has been reduced to 10 characters.
+
 = 1.0.1 =
 * Fixed: some issues in admin area.
 * Improved: added internal test to make it more robust.


### PR DESCRIPTION
Reduces token length from ~200 characters (base64 encoded) to just 10 alphanumeric characters, making URLs cleaner and easier to share

Fixes #5 