### PR TITLE
fix: address all Codex review issues (PR #8 + PR #9)

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -240,7 +240,11 @@
 		if (allSelected && variationData.variations) {
 			const matchingVariation = variationData.variations.find(function(variation) {
 				for (const attrName in selectedAttributes) {
-					if (variation.attributes[attrName] !== selectedAttributes[attrName]) {
+					const normalizedKey = attrName.startsWith('attribute_') ? attrName : 'attribute_' + attrName;
+					const variationValue = Object.prototype.hasOwnProperty.call(variation.attributes, normalizedKey)
+						? variation.attributes[normalizedKey]
+						: variation.attributes[attrName];
+					if (variationValue !== selectedAttributes[attrName]) {
 						return false;
 					}
 				}
@@ -373,9 +377,10 @@
 			return;
 		}
 
-		if (selectedOption.disabled || selectedOption.hasAttribute('disabled')) {
-			alert(jptcAdmin.i18n.variable_product_error);
-			jQuery('.jump-to-checkout-product-search').val(null).trigger('change');
+		// If a variable product parent is selected, wait for variation to be chosen.
+		const selectData = jQuery('.jump-to-checkout-product-search').select2('data');
+		const currentData = selectData && selectData[0] ? selectData[0] : {};
+		if (currentData.is_variable) {
 			return;
 		}
 

--- a/assets/js/variable-products.js
+++ b/assets/js/variable-products.js
@@ -206,7 +206,12 @@
 			const matchingVariation = currentVariationData.variations.find(function(variation) {
 				let matches = true;
 				for (const attrName in selectedAttributes) {
-					if (variation.attributes[attrName] !== selectedAttributes[attrName]) {
+					// WC stores variation attributes prefixed with "attribute_"; normalise before comparing.
+					const normalizedKey = attrName.startsWith('attribute_') ? attrName : 'attribute_' + attrName;
+					const variationValue = Object.prototype.hasOwnProperty.call(variation.attributes, normalizedKey)
+						? variation.attributes[normalizedKey]
+						: variation.attributes[attrName];
+					if (variationValue !== selectedAttributes[attrName]) {
 						matches = false;
 						break;
 					}

--- a/includes/Admin/AdminPanel.php
+++ b/includes/Admin/AdminPanel.php
@@ -196,8 +196,8 @@ class AdminPanel {
 						</table>
 					</div>
 
-					<?php do_action( 'jptc_render_expiry_section', true ); ?>
-					<?php do_action( 'jptc_render_coupon_section', true ); ?>
+					<?php $this->render_expiry_section(); ?>
+					<?php $this->render_coupon_section(); ?>
 
 					<div class="jump-to-checkout-generate-section">
 						<button type="button" class="button button-primary button-large jump-to-checkout-generate-link">
@@ -273,6 +273,94 @@ class AdminPanel {
 			</div>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Render expiry section
+	 *
+	 * @return void
+	 */
+	private function render_expiry_section() {
+		?>
+		<div class="jump-to-checkout-expiry-section">
+			<h3><?php echo esc_html__( 'Link Expiry', 'jump-to-checkout' ); ?></h3>
+			<label>
+				<input type="radio" name="jptc_expiry_type" value="never" checked />
+				<?php echo esc_html__( 'Never expires', 'jump-to-checkout' ); ?>
+			</label>
+			<label>
+				<input type="radio" name="jptc_expiry_type" value="custom" />
+				<?php echo esc_html__( 'Expires in', 'jump-to-checkout' ); ?>
+				<input type="number" name="jptc_expiry_hours" value="24" min="1" />
+				<?php echo esc_html__( 'hours', 'jump-to-checkout' ); ?>
+			</label>
+			<p class="description">
+				<?php esc_html_e( 'Set when this link should expire. After expiration, the link will no longer work.', 'jump-to-checkout' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render coupon section
+	 *
+	 * @return void
+	 */
+	private function render_coupon_section() {
+		$coupons = $this->get_available_coupons();
+		?>
+		<div class="jump-to-checkout-coupon-section">
+			<h3><?php echo esc_html__( 'Automatic Coupon', 'jump-to-checkout' ); ?></h3>
+			<label>
+				<?php echo esc_html__( 'Apply coupon code automatically:', 'jump-to-checkout' ); ?>
+				<select name="jptc_coupon_code">
+					<option value=""><?php echo esc_html__( 'None', 'jump-to-checkout' ); ?></option>
+					<?php foreach ( $coupons as $coupon_code => $coupon_name ) : ?>
+						<option value="<?php echo esc_attr( $coupon_code ); ?>">
+							<?php echo esc_html( $coupon_name ); ?>
+						</option>
+					<?php endforeach; ?>
+				</select>
+			</label>
+			<p class="description">
+				<?php esc_html_e( 'Select a coupon code to automatically apply when customers click this link.', 'jump-to-checkout' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Get available WooCommerce coupons
+	 *
+	 * @return array Array of coupon_code => label.
+	 */
+	private function get_available_coupons() {
+		if ( ! class_exists( 'WC_Coupon' ) ) {
+			return array();
+		}
+
+		$coupon_ids = get_posts(
+			array(
+				'post_type'        => 'shop_coupon',
+				'post_status'      => 'publish',
+				'posts_per_page'   => -1,
+				'fields'           => 'ids',
+				'suppress_filters' => false,
+			)
+		);
+
+		$result = array();
+		foreach ( array_unique( $coupon_ids ) as $coupon_id ) {
+			$coupon = new \WC_Coupon( $coupon_id );
+			if ( ! $coupon->get_id() ) {
+				continue;
+			}
+			$code            = $coupon->get_code();
+			$label           = $coupon->get_description() ? $coupon->get_description() : $code;
+			$result[ $code ] = $label . ' (' . $code . ')';
+		}
+
+		return $result;
 	}
 
 	/**
@@ -412,14 +500,12 @@ class AdminPanel {
 					$product_name .= ' (' . $product->get_sku() . ')';
 				}
 
-				// Variable products are never directly selectable; user must choose a variation.
+				// Variable products: selectable to trigger variation picker, but not directly addable.
 				if ( $product->is_type( 'variable' ) ) {
-					$product_name .= ' ' . __( '[Variable Product - Select variation below]', 'jump-to-checkout' );
-
 					$results[] = array(
-						'id'       => $product->get_id(),
-						'text'     => wp_strip_all_tags( $product_name ),
-						'disabled' => true,
+						'id'          => $product->get_id(),
+						'text'        => wp_strip_all_tags( $product_name ),
+						'is_variable' => true,
 					);
 					continue;
 				}

--- a/includes/Admin/AdvancedAnalytics.php
+++ b/includes/Admin/AdvancedAnalytics.php
@@ -168,7 +168,9 @@ class AdvancedAnalytics {
 		$date_from = isset( $_GET['date_from'] ) ? sanitize_text_field( wp_unslash( $_GET['date_from'] ) ) : gmdate( 'Y-m-d', strtotime( '-30 days' ) );
 		$date_to   = isset( $_GET['date_to'] ) ? sanitize_text_field( wp_unslash( $_GET['date_to'] ) ) : gmdate( 'Y-m-d' );
 
-		$links = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE created_at >= %s AND created_at <= %s ORDER BY created_at DESC", $date_from, $date_to ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$date_to_end = $date_to . ' 23:59:59';
+
+		$links = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE created_at >= %s AND created_at <= %s ORDER BY created_at DESC", $date_from, $date_to_end ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$total_links       = count( $links );
 		$active_links      = 0;

--- a/includes/Admin/LinksManager.php
+++ b/includes/Admin/LinksManager.php
@@ -150,7 +150,15 @@ class LinksManager {
 			</div>
 
 			<div class="jump-to-checkout-toolbar">
-				<?php do_action( 'jptc_admin_export_button' ); ?>
+				<?php
+				$export_url = wp_nonce_url(
+					add_query_arg( array( 'jptc_export' => 'csv' ), admin_url( 'admin.php?page=jptc-manage-links' ) ),
+					'jptc_export_csv'
+				);
+				?>
+				<a href="<?php echo esc_url( $export_url ); ?>" class="button">
+					<?php echo esc_html__( 'Export to CSV', 'jump-to-checkout' ); ?>
+				</a>
 			</div>
 
 			<table class="wp-list-table widefat fixed striped jump-to-checkout-links-table">

--- a/includes/Core/AutomaticCoupons.php
+++ b/includes/Core/AutomaticCoupons.php
@@ -24,7 +24,6 @@ class AutomaticCoupons {
 	 */
 	public function __construct() {
 		add_action( 'jptc_before_redirect_to_checkout', array( $this, 'apply_coupon_to_link' ), 10, 1 );
-		add_action( 'jptc_render_coupon_section', array( $this, 'render_coupon_section' ), 10, 1 );
 		add_filter( 'jptc_ajax_link_data', array( $this, 'save_coupon_from_ajax' ), 10, 2 );
 		add_action( 'jptc_after_link_created', array( $this, 'save_coupon_after_link_created' ), 10, 2 );
 	}
@@ -55,7 +54,7 @@ class AutomaticCoupons {
 			return;
 		}
 
-		if ( WC()->cart ) {
+		if ( WC()->cart && ! WC()->cart->has_discount( $coupon_code ) ) {
 			WC()->cart->apply_coupon( $coupon_code );
 		}
 	}
@@ -89,65 +88,6 @@ class AutomaticCoupons {
 		}
 
 		return update_option( 'jptc_link_coupon_' . $link_id, sanitize_text_field( $coupon_code ) );
-	}
-
-	/**
-	 * Render coupon section in admin
-	 *
-	 * @param bool $can_create Whether user can create links.
-	 * @return void
-	 */
-	public function render_coupon_section( $can_create ) {
-		$coupons = $this->get_available_coupons();
-		?>
-		<div class="jump-to-checkout-coupon-section">
-			<h3><?php echo esc_html__( 'Automatic Coupon', 'jump-to-checkout' ); ?></h3>
-			<label>
-				<?php echo esc_html__( 'Apply coupon code automatically:', 'jump-to-checkout' ); ?>
-				<select name="jptc_coupon_code" <?php echo ! $can_create ? 'disabled' : ''; ?>>
-					<option value=""><?php echo esc_html__( 'None', 'jump-to-checkout' ); ?></option>
-					<?php foreach ( $coupons as $coupon_code => $coupon_name ) : ?>
-						<option value="<?php echo esc_attr( $coupon_code ); ?>">
-							<?php echo esc_html( $coupon_name ); ?>
-						</option>
-					<?php endforeach; ?>
-				</select>
-			</label>
-			<p class="description">
-				<?php esc_html_e( 'Select a coupon code to automatically apply when customers click this link.', 'jump-to-checkout' ); ?>
-			</p>
-		</div>
-		<?php
-	}
-
-	/**
-	 * Get available coupons
-	 *
-	 * @return array Array of coupon_code => coupon_name.
-	 */
-	private function get_available_coupons() {
-		if ( ! function_exists( 'wc_get_coupons' ) ) {
-			return array();
-		}
-
-		$coupons = wc_get_coupons(
-			array(
-				'posts_per_page' => -1,
-				'post_status'    => 'publish',
-			)
-		);
-
-		$result = array();
-		foreach ( $coupons as $coupon ) {
-			$coupon_obj = new \WC_Coupon( $coupon->ID );
-			if ( $coupon_obj->get_id() ) {
-				$code            = $coupon_obj->get_code();
-				$name            = $coupon_obj->get_description() ? $coupon_obj->get_description() : $code;
-				$result[ $code ] = $name . ' (' . $code . ')';
-			}
-		}
-
-		return $result;
 	}
 
 	/**

--- a/includes/Core/DataExport.php
+++ b/includes/Core/DataExport.php
@@ -24,7 +24,6 @@ class DataExport {
 	 */
 	public function __construct() {
 		add_action( 'admin_init', array( $this, 'handle_export_request' ) );
-		add_action( 'jptc_admin_export_button', array( $this, 'render_export_button' ) );
 	}
 
 	/**
@@ -116,20 +115,4 @@ class DataExport {
 		exit;
 	}
 
-	/**
-	 * Render export button
-	 *
-	 * @return void
-	 */
-	public function render_export_button() {
-		$export_url = wp_nonce_url(
-			add_query_arg( array( 'jptc_export' => 'csv' ), admin_url( 'admin.php?page=jptc-manage-links' ) ),
-			'jptc_export_csv'
-		);
-		?>
-		<a href="<?php echo esc_url( $export_url ); ?>" class="button">
-			<?php echo esc_html__( 'Export to CSV', 'jump-to-checkout' ); ?>
-		</a>
-		<?php
-	}
 }

--- a/includes/Core/Features.php
+++ b/includes/Core/Features.php
@@ -20,6 +20,46 @@ defined( 'ABSPATH' ) || exit;
  */
 class Features {
 
+	/** @return true */
+	public static function is_pro() {
+		return true;
+	}
+
+	/** @return string */
+	public static function get_upgrade_url() {
+		return '';
+	}
+
+	/** @return true */
+	public static function can_export() {
+		return true;
+	}
+
+	/** @return true */
+	public static function can_use_coupons() {
+		return true;
+	}
+
+	/** @return true */
+	public static function can_use_templates() {
+		return true;
+	}
+
+	/** @return true */
+	public static function can_use_webhooks() {
+		return true;
+	}
+
+	/** @return true */
+	public static function can_use_api() {
+		return true;
+	}
+
+	/** @return true */
+	public static function has_analytics() {
+		return true;
+	}
+
 	/**
 	 * Get current active links count
 	 *

--- a/includes/Core/JumpToCheckout.php
+++ b/includes/Core/JumpToCheckout.php
@@ -164,14 +164,12 @@ class JumpToCheckout {
 			$this->db = new \CLOSE\JumpToCheckout\Database\Database();
 		}
 
-		// FREE version: never calculate expiry. PRO can override via filter.
-		$expiry = apply_filters( 'jptc_link_expiry', 0, $name, $products );
+		$expiry = apply_filters( 'jptc_link_expiry', $expiry, $name, $products );
 
 		// Generate short token (new format: just a random ID, products stored in DB).
 		$token = $this->generate_short_token();
 		$url   = home_url( '/jump-to-checkout/' . $token );
 
-		// FREE version: never calculate expiry data. PRO will add it via filter.
 		$link_data = array(
 			'name'         => $name,
 			'token'        => $token,
@@ -181,7 +179,6 @@ class JumpToCheckout {
 			'expires_at'   => null,
 		);
 
-		// Allow PRO to modify link data before insert (PRO will add expiry data here).
 		$link_data = apply_filters( 'jptc_link_data_before_insert', $link_data, $name, $products, $expiry );
 
 		$link_id = $this->db->insert_link( $link_data );

--- a/includes/Core/LinkExpiration.php
+++ b/includes/Core/LinkExpiration.php
@@ -30,7 +30,6 @@ class LinkExpiration {
 		add_filter( 'jptc_link_is_expired', array( $this, 'check_link_expired' ), 10, 2 );
 		add_filter( 'jptc_token_expiry_check', array( $this, 'check_token_expiry' ), 10, 2 );
 		add_filter( 'jptc_ajax_link_expiry', array( $this, 'get_ajax_expiry' ), 10, 2 );
-		add_action( 'jptc_render_expiry_section', array( $this, 'render_expiry_section' ), 10, 1 );
 	}
 
 	/**
@@ -42,7 +41,7 @@ class LinkExpiration {
 	 */
 	public function get_ajax_expiry( $expiry, $post_data ) {
 		if ( isset( $post_data['expiry'] ) ) {
-			$expiry = absint( $post_data['expiry'] );
+			$expiry = max( 0, (int) $post_data['expiry'] );
 		}
 		return $expiry;
 	}
@@ -136,30 +135,4 @@ class LinkExpiration {
 		return false;
 	}
 
-	/**
-	 * Render expiry section in admin
-	 *
-	 * @param bool $can_create Whether user can create links.
-	 * @return void
-	 */
-	public function render_expiry_section( $can_create ) {
-		?>
-		<div class="jump-to-checkout-expiry-section">
-			<h3><?php echo esc_html__( 'Link Expiry', 'jump-to-checkout' ); ?></h3>
-			<label>
-				<input type="radio" name="jptc_expiry_type" value="never" checked <?php echo ! $can_create ? 'disabled' : ''; ?> />
-				<?php echo esc_html__( 'Never expires', 'jump-to-checkout' ); ?>
-			</label>
-			<label>
-				<input type="radio" name="jptc_expiry_type" value="custom" <?php echo ! $can_create ? 'disabled' : ''; ?> />
-				<?php echo esc_html__( 'Expires in', 'jump-to-checkout' ); ?>
-				<input type="number" name="jptc_expiry_hours" value="24" min="1" <?php echo ! $can_create ? 'disabled' : ''; ?> />
-				<?php echo esc_html__( 'hours', 'jump-to-checkout' ); ?>
-			</label>
-			<p class="description">
-				<?php esc_html_e( 'Set when this link should expire. After expiration, the link will no longer work.', 'jump-to-checkout' ); ?>
-			</p>
-		</div>
-		<?php
-	}
 }

--- a/tests/Unit/AutomaticCouponsTest.php
+++ b/tests/Unit/AutomaticCouponsTest.php
@@ -130,10 +130,6 @@ class Test_AutomaticCoupons extends WP_UnitTestCase {
 		);
 		$this->assertGreaterThan(
 			0,
-			has_action( 'jptc_render_coupon_section', array( $this->automatic_coupons, 'render_coupon_section' ) )
-		);
-		$this->assertGreaterThan(
-			0,
 			has_filter( 'jptc_ajax_link_data', array( $this->automatic_coupons, 'save_coupon_from_ajax' ) )
 		);
 		$this->assertGreaterThan(

--- a/tests/Unit/JumpToCheckoutTest.php
+++ b/tests/Unit/JumpToCheckoutTest.php
@@ -8,6 +8,7 @@
 namespace CLOSE\JumpToCheckout\Tests;
 
 use CLOSE\JumpToCheckout\Core\JumpToCheckout;
+use CLOSE\JumpToCheckout\Core\LinkExpiration;
 use CLOSE\JumpToCheckout\Database\Database;
 use WP_UnitTestCase;
 
@@ -34,6 +35,9 @@ class Test_JumpToCheckout extends WP_UnitTestCase {
 		// Create database table.
 		$db = new Database();
 		$db->create_table();
+
+		// Register expiry filters so generate_link() persists expiry_hours correctly.
+		new LinkExpiration();
 
 		// Create instance (this will register hooks, which is fine for tests).
 		$this->jump_to_checkout = new JumpToCheckout();


### PR DESCRIPTION
## Summary

Fixes all issues flagged by Codex in PR #8 and PR #9 reviews. Clean branch from `main` with no conflicts.

## Fixes

**Logic bugs (PR #8 Codex review)**
- **LinkExpiration**: `generate_link()` was passing `0` hardcoded to `jptc_link_expiry` filter — links never expired. Fixed by passing `$expiry` as initial value.
- **LinkExpiration**: `absint(-10)` returns `10` — negative expiry was silently accepted. Fixed with `max(0, intval())`.
- **AutomaticCoupons**: `wc_get_coupons()` return type not guaranteed — dropdown was empty. Fixed with `get_posts('shop_coupon')` + `array_unique`.
- **AutomaticCoupons**: no guard before `apply_coupon()` — coupon applied twice if link clicked again. Fixed with `has_discount()` check.
- **AdvancedAnalytics**: `date_to` compared against midnight — today's links excluded from charts. Fixed by appending `23:59:59`.
- **VariableProducts (JS)**: attribute keys `pa_color` vs `attribute_pa_color` mismatch — variation selector never matched. Fixed in both `admin.js` and `variable-products.js`.
- **Features**: backward-compat stubs removed — third-party code calling `is_pro()`, `can_export()`, etc. would fatal. Restored all stubs returning `true`/empty string.

**Admin UI / UX (PR #9 Codex review)**
- **Coupon dropdown appearing twice**: moved rendering out of `do_action` hooks into direct method calls in `AdminPanel` and `LinksManager`.
- **Variable product picker never opens**: parent product was `disabled` in Select2 so `select2:select` never fired. Now returned as selectable with `is_variable: true` flag; JS opens variation picker on selection and blocks direct cart add until variation is chosen.

**Tests**
- `AutomaticCouponsTest`: removed stale assertion for `jptc_render_coupon_section` hook (no longer registered).
- `JumpToCheckoutTest`: instantiate `LinkExpiration` in `setUp()` so `jptc_link_data_before_insert` filter is registered before expiry assertions run.

## Test plan

- [ ] PHPUnit passes: `composer test`
- [ ] Coupon dropdown shows each coupon once
- [ ] Create link with custom expiry → `expires_at` stored, link stops working after expiry
- [ ] Create link with negative expiry input → treated as 0 (no expiry)
- [ ] Coupon applied once even if link clicked twice in same session
- [ ] Analytics shows today's links in charts
- [ ] Search for variable product → variation picker opens, selecting variation adds it correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)